### PR TITLE
start.html usb0 use full path

### DIFF
--- a/START.htm
+++ b/START.htm
@@ -150,7 +150,7 @@ you serial access to your board.</p>
     <h3 id="step3">Step #3: Browse to your board</h3>
     <p>Using either <a target="_blank" href="http://www.google.com/chrome">Chrome</a> or <a target="_blank" href="http://www.mozilla.org/firefox">Firefox</a> (Internet Explorer will <b>NOT</b> work), browse to the web server running on your board. It will load a presentation showing you the capabilities of the board. Use the arrow keys on your keyboard to navigate the presentation.</p>
     <ul class="arrow">
-     <li>Click here to launch: <a href="http://192.168.7.2" target="_blank">http://192.168.7.2</a></li>
+     <li>Click here to launch: <a href="http://192.168.7.2/bone101/Support/bone101/" target="_blank">http://192.168.7.2</a></li>
     </ul>
     <a href="http://192.168.7.2"><img src="Docs/images/bone101.png" width="600px" /></a>
 


### PR DESCRIPTION
By having the full path here, it works around a http://192.168.7.2/ -> http://192.168.8.1/ redirect
